### PR TITLE
change from co test billing to alphagov

### DIFF
--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -14,7 +14,7 @@ class GithubService
     end
 
     new_branch_name = 'new-aws-account-' + account_name
-    github_repo = 'cabinetoffice/cope-aws-account-billing-test'
+    github_repo = 'alphagov/aws-billing-account'
     main = @client.commit(github_repo, 'main')
     create_branch github_repo, new_branch_name, main.sha
 

--- a/test/controllers/check_your_answers_controller_test.rb
+++ b/test/controllers/check_your_answers_controller_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'webmock'
 
-ACCOUNT_MANAGEMENT_GITHUB_API = "https://api.github.com/repos/cabinetoffice/cope-aws-account-billing-test"
+ACCOUNT_MANAGEMENT_GITHUB_API = "https://api.github.com/repos/alphagov/aws-billing-account"
 
 class CheckYourAnswersControllerTest < ActionDispatch::IntegrationTest
   include WebMock::API


### PR DESCRIPTION
Made target repo `alphagov/aws-billing-account` instead of our test repo `cabinetoffice/cope-aws-account-billing-test`