### PR TITLE
COPE 1332 - Update GDS signposting to link directly to their AWS request process

### DIFF
--- a/app/views/organisation/organisation.html.erb
+++ b/app/views/organisation/organisation.html.erb
@@ -67,7 +67,7 @@
       <p govuk-body>If you need to be invoiced directly and are not in the options above please contact: <a class="govuk-link" href="mailto:<%= Rails.application.config.support_email %>"><%= Rails.application.config.support_email %></a></p>      
       <%= f.submit 'Next', class: 'govuk-button', data: { module: "govuk-button" } %>
       <h3 class="govuk-heading-m">GDS or i.AI cost centres </h3>
-      <p govuk-body>Your request process has changed, please refer to the new process outlined in <a href="https://gds-way.digital.cabinet-office.gov.uk/manuals/working-with-aws-accounts.html#create-aws-accounts" target="_blank" rel="noopener noreferrer">The GDS Way - Create AWS Accounts</a></p>
+      <p govuk-body>Your request process has changed, please refer to the new process outlined in <a href="https://github.com/alphagov/gds-aws-organisation-accounts/blob/main/README.md" target="_blank" rel="noopener noreferrer">GDS documentation</a></p>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
[JIRA Ticket
](https://technologyprogramme.atlassian.net/jira/software/c/projects/COPE/boards/514?selectedIssue=COPE-1332)

Following a meeting with GDS EE, it was decided that it would be better to signpost users directly to the GDS AWS request an account process in their GitHub, instead of linking to GDS Way documentation.