### PR TITLE
update github org from alphagov to cabinetoffice

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ For more details regarding usage and setting up secrets, see [request-an-aws-acc
 
   - `GOOGLE_CLIENT_ID`: an OAuth2 Client ID
   - `GOOGLE_CLIENT_SECRET`: an OAuth2 Client secret
-  - `GITHUB_PERSONAL_ACCESS_TOKEN`: the PAT required to act on requied [alphagov/aws-billing-account](https://github.com/alphagov/aws-billing-account) repository
+  - `GITHUB_PERSONAL_ACCESS_TOKEN`: the PAT required to act on requied [cabinetoffice/aws-billing-account](https://github.com/cabinetoffice/aws-billing-account) repository
   - `NOTIFY_API_KEY`: a key to use the Notify API to send emails
   - `RAILS_MASTER_KEY`: the key that has been used to encode `config/credentials.yml.enc`
 

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -14,7 +14,7 @@ class GithubService
     end
 
     new_branch_name = 'new-aws-account-' + account_name
-    github_repo = 'alphagov/aws-billing-account'
+    github_repo = 'cabinetoffice/aws-billing-account'
     master = @client.commit(github_repo, 'master')
     create_branch github_repo, new_branch_name, master.sha
 

--- a/test/controllers/check_your_answers_controller_test.rb
+++ b/test/controllers/check_your_answers_controller_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'webmock'
 
-ACCOUNT_MANAGEMENT_GITHUB_API = "https://api.github.com/repos/alphagov/aws-billing-account"
+ACCOUNT_MANAGEMENT_GITHUB_API = "https://api.github.com/repos/cabinetoffice/aws-billing-account"
 
 class CheckYourAnswersControllerTest < ActionDispatch::IntegrationTest
   include WebMock::API


### PR DESCRIPTION
Updating the GitHub organisation the repository resides in.